### PR TITLE
Fix permissions and add fallback when move op fails.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -58,7 +58,7 @@ exports.update = function update(callback) {
 
     // Fetch the remote resource as that is frequently updated
     fs.readFile(pathToYaml, 'utf8', function loading(err, remote) {
-    // request(exports.remote, function downloading(err, res, remote) {
+      // request(exports.remote, function downloading(err, res, remote) {
       if (err) return callback(err);
 
       // Append get some local additions that are missing from the source
@@ -74,12 +74,17 @@ exports.update = function update(callback) {
           //
           // Save to a tmp file to avoid potential concurrency issues.
           //
-          tmp.file(function (err, tempFilePath) {
+          tmp.file({ mode: 0o644 }, function (err, tempFilePath) {
             if (err) return;
             fs.writeFile(tempFilePath, source, function idk(err) {
               if (err) return
               fs.rename(tempFilePath, exports.output, function(err) {
-
+                if (err) {
+                  fs.copyFile(tempFilePath, exports.output, function(err) {
+                    if (err) return;
+                    fs.unlink(tempFilePath, function() {});
+                  });
+                }
               });
             });
           });


### PR DESCRIPTION
Fixes https://github.com/schmod/useragent-ng/issues/6 and issue with rename on some systems `Error: EXDEV: cross-device link not permitted, rename `